### PR TITLE
change package name and publish on npm

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,11 @@
+
+/node_modules
+/bower_components
+
+/dist
+/*.html
+
+/gulpfile.js
+/_travis.yml
+/bower.json
+/.eslintrc

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "smoothscroll",
-  "version": "0.1.0",
+  "name": "smoothscroll-polyfill",
+  "version": "0.2.1",
   "authors": [
     {
       "name": "Dustan Kasten",
@@ -20,7 +20,7 @@
     "gulp-uglify": "^1.2.0"
   },
   "description": "Polyfill for smooth scroll behavior",
-  "main": "dist/smoothscroll.js",
+  "main": "smoothscroll.js",
   "scripts": {
     "test": "gulp lint"
   },


### PR DESCRIPTION
Since the name is token, I used `smoothscroll-polyfill` as the new package name. It's not backward-compatible. And I changed the version to `0.2.1`.