### PR TITLE
Support {block: 'end'} 

### DIFF
--- a/dist/smoothscroll.js
+++ b/dist/smoothscroll.js
@@ -1,5 +1,5 @@
 /*
- * smoothscroll polyfill - v0.3.3
+ * smoothscroll polyfill - v0.4.0
  * https://iamdustan.github.io/smoothscroll
  * 2016 (c) Dustan Kasten, Jeremias Menichelli - MIT License
  */
@@ -233,6 +233,29 @@
       });
     }
 
+    function scrollWithinParentElem(el, opts) {
+        var scrollableParent = findScrollableParent(el);
+        if (scrollableParent === d.body) {
+            return;
+        }
+
+        var clientRects = el.getBoundingClientRect();
+        var parentRects = scrollableParent.getBoundingClientRect();
+        var clientAdj = clientRects.top;
+        if (opts.block === 'end') {
+            var scrollbarHeight = scrollableParent.offsetHeight - scrollableParent.clientHeight
+            clientAdj = clientRects.bottom - parentRects.height + scrollbarHeight;
+        }
+
+        // reveal element inside parent
+        smoothScroll.call(
+          this,
+          scrollableParent,
+          scrollableParent.scrollLeft + clientRects.left - parentRects.left,
+          scrollableParent.scrollTop + clientAdj - parentRects.top
+        );
+    }
+
     /*
      * ORIGINAL METHODS OVERRIDES
      */
@@ -290,29 +313,9 @@
       }
 
       // LET THE SMOOTHNESS BEGIN!
-      var scrollableParent = findScrollableParent(this);
-      var parentRects = scrollableParent.getBoundingClientRect();
       var clientRects = this.getBoundingClientRect();
 
-      if (scrollableParent !== d.body) {
-        var clientAdj = clientRects.top;
-        if (opts.block === 'end') {
-            var scrollbarHeight = scrollableParent.offsetHeight - scrollableParent.clientHeight
-            clientAdj = clientRects.bottom - parentRects.height + scrollbarHeight;
-        }
-
-        // reveal element inside parent
-        smoothScroll.call(
-          this,
-          scrollableParent,
-          scrollableParent.scrollLeft + clientRects.left - parentRects.left,
-          scrollableParent.scrollTop + clientAdj - parentRects.top
-        );
-
-        // scroll parent into view
-        return scrollableParent.scrollIntoView(arguments[0]);
-      }
-
+      scrollWithinParentElem(this, opts);
       w.scrollBy({
           left: clientRects.left,
           top: opts.block !== 'end' ? clientRects.top : clientRects.bottom - w.innerHeight,

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "title": "smoothscroll",
   "name": "smoothscroll-polyfill",
-  "version": "0.3.3",
+  "version": "0.4.0",
   "author": {
     "name": "Dustan Kasten",
     "email": "dustan.kasten@gmail.com",

--- a/src/smoothscroll.js
+++ b/src/smoothscroll.js
@@ -61,11 +61,11 @@
 
     /**
      * indicates if a smooth behavior should be applied
-     * @method shouldBailOut
+     * @method scrollIsInstant
      * @param {Number|Object} x
      * @returns {Boolean}
      */
-    function shouldBailOut(x) {
+    function scrollIsInstant(x) {
       if (typeof x !== 'object'
             || x.behavior === undefined
             || x.behavior === 'auto'
@@ -186,7 +186,7 @@
     // w.scroll and w.scrollTo
     w.scroll = w.scrollTo = function() {
       // avoid smooth behavior if not required
-      if (shouldBailOut(arguments[0])) {
+      if (scrollIsInstant(arguments[0])) {
         original.scroll.call(
           w,
           arguments[0].left || arguments[0],
@@ -207,7 +207,7 @@
     // w.scrollBy
     w.scrollBy = function() {
       // avoid smooth behavior if not required
-      if (shouldBailOut(arguments[0])) {
+      if (scrollIsInstant(arguments[0])) {
         original.scrollBy.call(
           w,
           arguments[0].left || arguments[0],
@@ -228,7 +228,7 @@
     // Element.prototype.scrollIntoView
     Element.prototype.scrollIntoView = function() {
       // avoid smooth behavior if not required
-      if (shouldBailOut(arguments[0])) {
+      if (scrollIsInstant(arguments[0])) {
         original.scrollIntoView.call(this, arguments[0] || true);
         return;
       }

--- a/src/smoothscroll.js
+++ b/src/smoothscroll.js
@@ -60,6 +60,54 @@
     }
 
     /**
+     * Normalizes valid scrollIntoView arguments into an arguments object
+     * @method normalizeArgs
+     * @param {Boolean|Object=} x
+     * @returns {Object}
+     */
+    function normalizeArgs(x) {
+      if (typeof x === 'undefined') {
+        return {
+          block: 'start',
+          behavior: 'auto'
+        };
+      }
+
+      if (typeof x === 'boolean') {
+        return {
+          block: (x ? 'start' : 'end'),
+          behavior: 'auto'
+        };
+      }
+
+      if (typeof x === 'object') {
+        if (
+          (x.behavior !== undefined) &&
+          (x.behavior !== 'auto') &&
+          (x.behavior !== 'instant') &&
+          (x.behavior !== 'smooth')
+        ) {
+          throw new TypeError('behavior not valid');
+        }
+
+        if (
+          (x.block !== undefined) &&
+          (x.block !== 'start') &&
+          (x.block !== 'end')
+        ) {
+          throw new TypeError('block not valid');
+        }
+
+        return {
+          block: x.block === 'end' ? 'end' : 'start',
+          behavior: x.behavior === 'smooth' ? 'smooth' : 'auto'
+        }
+      }
+
+      throw new TypeError('scrollIntoView accepts undefined, boolean or object as its first argument');
+    }
+
+    /**
      * indicates if a smooth behavior should be applied
      * @method scrollIsInstant
      * @param {Number|Object} x
@@ -227,8 +275,10 @@
 
     // Element.prototype.scrollIntoView
     Element.prototype.scrollIntoView = function() {
+      var opts = normalizeArgs(arguments[0]);
+
       // avoid smooth behavior if not required
-      if (scrollIsInstant(arguments[0])) {
+      if (scrollIsInstant(arguments[0]) && opts.block == "top") {
         original.scrollIntoView.call(this, arguments[0] || true);
         return;
       }
@@ -239,27 +289,29 @@
       var clientRects = this.getBoundingClientRect();
 
       if (scrollableParent !== d.body) {
+        var clientAdj = clientRects.top;
+        if (opts.block === 'end') {
+            var scrollbarHeight = scrollableParent.offsetHeight - scrollableParent.clientHeight
+            clientAdj = clientRects.bottom - parentRects.height + scrollbarHeight;
+        }
+
         // reveal element inside parent
         smoothScroll.call(
           this,
           scrollableParent,
           scrollableParent.scrollLeft + clientRects.left - parentRects.left,
-          scrollableParent.scrollTop + clientRects.top - parentRects.top
+          scrollableParent.scrollTop + clientAdj - parentRects.top
         );
-        // reveal parent in viewport
-        w.scrollBy({
-          left: parentRects.left,
-          top: parentRects.top,
-          behavior: 'smooth'
-        });
-      } else {
-        // reveal element in viewport
-        w.scrollBy({
-          left: clientRects.left,
-          top: clientRects.top,
-          behavior: 'smooth'
-        });
+
+        // scroll parent into view
+        return scrollableParent.scrollIntoView(arguments[0]);
       }
+
+      w.scrollBy({
+          left: clientRects.left,
+          top: opts.block !== 'end' ? clientRects.top : clientRects.bottom - w.innerHeight,
+          behavior: opts.behavior
+      });
     };
   }
 

--- a/src/smoothscroll.js
+++ b/src/smoothscroll.js
@@ -227,6 +227,29 @@
       });
     }
 
+    function scrollWithinParentElem(el, opts) {
+        var scrollableParent = findScrollableParent(el);
+        if (scrollableParent === d.body) {
+            return;
+        }
+
+        var clientRects = el.getBoundingClientRect();
+        var parentRects = scrollableParent.getBoundingClientRect();
+        var clientAdj = clientRects.top;
+        if (opts.block === 'end') {
+            var scrollbarHeight = scrollableParent.offsetHeight - scrollableParent.clientHeight
+            clientAdj = clientRects.bottom - parentRects.height + scrollbarHeight;
+        }
+
+        // reveal element inside parent
+        smoothScroll.call(
+          this,
+          scrollableParent,
+          scrollableParent.scrollLeft + clientRects.left - parentRects.left,
+          scrollableParent.scrollTop + clientAdj - parentRects.top
+        );
+    }
+
     /*
      * ORIGINAL METHODS OVERRIDES
      */
@@ -284,29 +307,9 @@
       }
 
       // LET THE SMOOTHNESS BEGIN!
-      var scrollableParent = findScrollableParent(this);
-      var parentRects = scrollableParent.getBoundingClientRect();
       var clientRects = this.getBoundingClientRect();
 
-      if (scrollableParent !== d.body) {
-        var clientAdj = clientRects.top;
-        if (opts.block === 'end') {
-            var scrollbarHeight = scrollableParent.offsetHeight - scrollableParent.clientHeight
-            clientAdj = clientRects.bottom - parentRects.height + scrollbarHeight;
-        }
-
-        // reveal element inside parent
-        smoothScroll.call(
-          this,
-          scrollableParent,
-          scrollableParent.scrollLeft + clientRects.left - parentRects.left,
-          scrollableParent.scrollTop + clientAdj - parentRects.top
-        );
-
-        // scroll parent into view
-        return scrollableParent.scrollIntoView(arguments[0]);
-      }
-
+      scrollWithinParentElem(this, opts);
       w.scrollBy({
           left: clientRects.left,
           top: opts.block !== 'end' ? clientRects.top : clientRects.bottom - w.innerHeight,

--- a/src/smoothscroll.js
+++ b/src/smoothscroll.js
@@ -9,10 +9,12 @@
    */
 
   // polyfill
-  function polyfill() {
+  function polyfill(overrideBrowserImplementation) {
     // return when scrollBehavior interface is supported
     if ('scrollBehavior' in d.documentElement.style) {
-      return;
+      if (!overrideBrowserImplementation) {
+        return;
+      }
     }
 
     /*
@@ -266,6 +268,6 @@
     module.exports = { polyfill: polyfill };
   } else {
     // global
-    polyfill();
+    polyfill(window.__smoothscrollForcePolyfill);
   }
 })(window, document);

--- a/test/cases/smoothScrollIntoViewEnd.js
+++ b/test/cases/smoothScrollIntoViewEnd.js
@@ -1,0 +1,10 @@
+
+  // $('.scrollable-parent p:last-child').scrollIntoView();
+  later(function() {
+    $('.hello').scrollIntoView({behavior: 'smooth', block: 'end'});
+    later(function() {
+      // assertScroll(window.scrollY, 80)
+      // assertScroll($('.scrollable-parent').scrollTop, 673)
+      done()
+    })
+  })

--- a/test/cases/smoothScrollIntoViewStart.js
+++ b/test/cases/smoothScrollIntoViewStart.js
@@ -1,0 +1,9 @@
+// $('.scrollable-parent p:last-child').scrollIntoView();
+later(function() {
+  $('.hello').scrollIntoView({behavior: 'smooth', block: 'start'});
+  later(function() {
+    // assertScroll(window.scrollY, 80)
+    // assertScroll($('.scrollable-parent').scrollTop, 905)
+    done()
+  })
+})

--- a/test/harness.html
+++ b/test/harness.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>smoothscroll tests - basic</title>
+
+  <meta name="viewport" content="width=device-width">
+
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/normalize/4.1.1/normalize.min.css">
+  <link rel="stylesheet" href="support/test.css">
+  <link href='https://fonts.googleapis.com/css?family=Roboto+Condensed:400,700' rel='stylesheet' type='text/css'>
+
+</head>
+<body>
+  <div class="top-padder"></div>
+
+  <article class="scrollable-parent">
+    <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Qui iure obcaecati, repudiandae aspernatur cumque recusandae
+    adipisci consequuntur maiores, quo in nulla ratione facere distinctio beatae, quae consequatur ab labore dolorum.</p>
+    <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Qui iure obcaecati, repudiandae aspernatur cumque recusandae
+    adipisci consequuntur maiores, quo in nulla ratione facere distinctio beatae, quae consequatur ab labore dolorum.</p>
+    <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Qui iure obcaecati, repudiandae aspernatur cumque recusandae
+    adipisci consequuntur maiores, quo in nulla ratione facere distinctio beatae, quae consequatur ab labore dolorum.</p>
+    <h3 class="hello"><em>hello!</em></h3>
+    <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Qui iure obcaecati, repudiandae aspernatur cumque recusandae
+    adipisci consequuntur maiores, quo in nulla ratione facere distinctio beatae, quae consequatur ab labore dolorum.</p>
+    <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Qui iure obcaecati, repudiandae aspernatur cumque recusandae
+    adipisci consequuntur maiores, quo in nulla ratione facere distinctio beatae, quae consequatur ab labore dolorum.</p>
+    <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Qui iure obcaecati, repudiandae aspernatur cumque recusandae
+    adipisci consequuntur maiores, quo in nulla ratione facere distinctio beatae, quae consequatur ab labore dolorum.</p>
+  </article>
+  <div class="test-result"></div>
+
+  <!-- rAF polyfill -->
+  <script src="support/raf.js"></script>
+  <!-- Test support functions -->
+  <script src="support/test-core.js"></script>
+
+  <script>
+    window.__smoothscrollForcePolyfill = true
+    // add event listener on load
+    window.addEventListener('load', function() {
+      var config = parseQuery(window.location.search)
+
+      if (config.skipPolyfill !== 'true') {
+        var poly = document.createElement('script')
+        poly.src = "../src/smoothscroll.js"
+        document.body.appendChild(poly)
+      }
+
+      if (config.noScrollableParent == 'true') {
+        $('.scrollable-parent').classList.remove('scrollable-parent')
+      }
+
+      var testcase = document.createElement('script')
+      testcase.src = "cases/" + config.case + ".js"
+      document.body.appendChild(testcase)
+    });
+  </script>
+</body>
+</html>

--- a/test/index.html
+++ b/test/index.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>smooth scroll polyfill tests</title>
+
+  <meta name="viewport" content="width=device-width">
+
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/normalize/4.1.1/normalize.min.css">
+<body>
+    <style>
+        body {
+            display: flex;
+            justify-content: flex-start;
+            width: 10000px;
+        }
+        .testcase {
+            width: 350px;
+        }
+        h1 {
+            word-wrap: break-word;
+        }
+    </style>
+    <script>
+        function testCase(opts) {
+            var url = "harness.html?"
+            var description = ""
+            for (var k in opts) {
+                url = url + k + '=' + opts[k] + '&'
+                description += "<dt>"+k+"</dt><dd>"+opts[k]+"</dd>"
+            }
+            document.write(
+                '<div class="testcase">' +
+                '  <iframe' +
+                '    src="'+url+'"' +
+                '    height="600"' +
+                '    width="300"' +
+                '    scrollbars="no"' +
+                '  /></iframe>' +
+                '  <dl>' + description + '</dl>' +
+                '</div>'
+            )
+        }
+    </script>
+
+    <script>
+        var cases = ["smoothScrollIntoViewEnd", "smoothScrollIntoViewStart"];
+        for (var i = 0; i < cases.length; i++) {
+            testCase({
+                "case": cases[i],
+                "skipPolyfill": false,
+                "noScrollableParent": false
+            })
+            testCase({
+                "case": cases[i],
+                "skipPolyfill": true,
+                "noScrollableParent": false
+            })
+            testCase({
+                "case": cases[i],
+                "skipPolyfill": false,
+                "noScrollableParent": true
+            })
+            testCase({
+                "case": cases[i],
+                "skipPolyfill": true,
+                "noScrollableParent": true
+            })
+        }
+
+    </script>
+
+</body>
+</html>

--- a/test/support/raf.js
+++ b/test/support/raf.js
@@ -1,0 +1,32 @@
+
+// http://paulirish.com/2011/requestanimationframe-for-smart-animating/
+// http://my.opera.com/emoller/blog/2011/12/20/requestanimationframe-for-smart-er-animating
+
+// requestAnimationFrame polyfill by Erik Möller. fixes from Paul Irish and Tino Zijdel
+
+// MIT license
+
+(function() {
+var lastTime = 0;
+var vendors = ['ms', 'moz', 'webkit', 'o'];
+for(var x = 0; x < vendors.length && !window.requestAnimationFrame; ++x) {
+    window.requestAnimationFrame = window[vendors[x]+'RequestAnimationFrame'];
+    window.cancelAnimationFrame = window[vendors[x]+'CancelAnimationFrame']
+                               || window[vendors[x]+'CancelRequestAnimationFrame'];
+}
+
+if (!window.requestAnimationFrame)
+    window.requestAnimationFrame = function(callback, element) {
+        var currTime = new Date().getTime();
+        var timeToCall = Math.max(0, 16 - (currTime - lastTime));
+        var id = window.setTimeout(function() { callback(currTime + timeToCall); },
+          timeToCall);
+        lastTime = currTime + timeToCall;
+        return id;
+    };
+
+if (!window.cancelAnimationFrame)
+    window.cancelAnimationFrame = function(id) {
+        clearTimeout(id);
+    };
+}());

--- a/test/support/test-core.js
+++ b/test/support/test-core.js
@@ -1,0 +1,36 @@
+function $(selector) {
+    return document.querySelector(selector);
+}
+
+function later(cb) {
+  setTimeout(cb, 600)
+}
+
+function fail(msg) {
+    document.querySelector('.test-result').textContent += msg
+}
+
+function done(msg) {
+    var resultCtr = document.querySelector('.test-result')
+    if (resultCtr.textContent === "") {
+        resultCtr.classList.add('success')
+    }
+    resultCtr.textContent += "complete"
+}
+
+function assertScroll(actual, expected) {
+    // Allow a little bit of leeway
+    if (Math.abs(actual - expected) > 3) {
+        fail(":failure: Expected '" + actual + "' to be '" + expected + "':")
+    }
+}
+
+function parseQuery(qstr) {
+    var query = {};
+    var a = qstr.substr(1).split('&');
+    for (var i = 0; i < a.length; i++) {
+        var b = a[i].split('=');
+        query[decodeURIComponent(b[0])] = decodeURIComponent(b[1] || '');
+    }
+    return query;
+}

--- a/test/support/test.css
+++ b/test/support/test.css
@@ -1,0 +1,41 @@
+
+body {
+  background-color: #fefefe;
+  color: #212121;
+  font-family: 'Roboto Condensed', Arial, sans-serif;
+  font-size: 20px;
+
+  text-rendering: optimizeLegibility;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.top-padder {
+    width: 100%;
+    height: 400px;
+}
+
+.scrollable-parent {
+  background-color: #efefef;
+  border-radius: 4px;
+  margin: 20px 0 0;
+  max-height: 200px;
+  overflow: scroll;
+  padding: 30px 50px;
+}
+.hello {
+  text-align: center;
+}
+
+.test-result {
+    position: fixed;
+    top: 50%;
+    left: 0;
+    right: 0;
+    text-align: center;
+    color: red;
+}
+
+.test-result.success {
+    color: green;
+}


### PR DESCRIPTION
I've broken my work into four logically separate commits for easy review.

The test harness renders a sequence of iframes with different setups. I found it invaluable when comparing behavior across browsers.

Adding support for overriding browser builtins made comparative testing much easier. I also plan to use it in my application because firefox's implementation has bugs.

Renaming `shouldBailOut` to `scrollIsInstant` makes the `block: end` stuff read much better.

The final change actually implements the `block: 'end'` scroll behavior.
