### PR TITLE
Reject parent with overflow set to visible

### DIFF
--- a/dist/smoothscroll.js
+++ b/dist/smoothscroll.js
@@ -95,11 +95,23 @@
      * @returns {Node} el
      */
     function findScrollableParent(el) {
+      var isBody;
+      var hasScrollableSpace;
+      var hasVisibleOverflow;
+
       do {
         el = el.parentNode;
-      } while (el !== d.body
-              && !(el.clientHeight < el.scrollHeight
-              || el.clientWidth < el.scrollWidth));
+
+        // set condition variables
+        isBody = el === d.body;
+        hasScrollableSpace =
+          el.clientHeight < el.scrollHeight ||
+          el.clientWidth < el.scrollWidth;
+        hasVisibleOverflow =
+          w.getComputedStyle(el, null).overflow === 'visible';
+      } while (!isBody && !(hasScrollableSpace && !hasVisibleOverflow));
+
+      isBody = hasScrollableSpace = hasVisibleOverflow = null;
 
       return el;
     }

--- a/src/smoothscroll.js
+++ b/src/smoothscroll.js
@@ -89,11 +89,23 @@
      * @returns {Node} el
      */
     function findScrollableParent(el) {
+      var isBody;
+      var hasScrollableSpace;
+      var hasVisibleOverflow;
+
       do {
         el = el.parentNode;
-      } while (el !== d.body
-              && !(el.clientHeight < el.scrollHeight
-              || el.clientWidth < el.scrollWidth));
+
+        // set condition variables
+        isBody = el === d.body;
+        hasScrollableSpace =
+          el.clientHeight < el.scrollHeight ||
+          el.clientWidth < el.scrollWidth;
+        hasVisibleOverflow =
+          w.getComputedStyle(el, null).overflow === 'visible';
+      } while (!isBody && !(hasScrollableSpace && !hasVisibleOverflow));
+
+      isBody = hasScrollableSpace = hasVisibleOverflow = null;
 
       return el;
     }


### PR DESCRIPTION
@iamdustan this fixes issue #36 review when you have time to see if I am missing something.

_**Description:** in cases where the overflow style property is set to visible and children are absolute positioned the script needs to scroll the body instead of the scrollable parent._

@KitaitiMakoto with this fix, the example you provided in theh first comment of the issue is mitigated; after merged test it on your project locally to see if it works there too.
