### PR TITLE
Check for null in bailout

### DIFF
--- a/dist/smoothscroll.js
+++ b/dist/smoothscroll.js
@@ -71,10 +71,12 @@
      */
     function shouldBailOut(x) {
       if (typeof x !== 'object'
+            || x === null
             || x.behavior === undefined
             || x.behavior === 'auto'
             || x.behavior === 'instant') {
-        // first arg not an object, or behavior is auto, instant or undefined
+        // first arg not an object/null
+        // or behavior is auto, instant or undefined
         return true;
       }
 

--- a/src/smoothscroll.js
+++ b/src/smoothscroll.js
@@ -65,10 +65,12 @@
      */
     function shouldBailOut(x) {
       if (typeof x !== 'object'
+            || x === null
             || x.behavior === undefined
             || x.behavior === 'auto'
             || x.behavior === 'instant') {
-        // first arg not an object, or behavior is auto, instant or undefined
+        // first arg not an object/null
+        // or behavior is auto, instant or undefined
         return true;
       }
 


### PR DESCRIPTION
Currently this fails on line 68 and isn't in line with current browser implementations.
In chrome the following works fine.

```js
window.scrollTo(null, 100)
```

But breaks with the polyfill.