### PR TITLE
Fix scrolling inside fixed elements

### DIFF
--- a/src/smoothscroll.js
+++ b/src/smoothscroll.js
@@ -94,6 +94,8 @@
       var isBody;
       var hasScrollableSpace;
       var hasVisibleOverflow;
+      var isFixed;
+      var style;
 
       do {
         el = el.parentNode;
@@ -103,11 +105,13 @@
         hasScrollableSpace =
           el.clientHeight < el.scrollHeight ||
           el.clientWidth < el.scrollWidth;
-        hasVisibleOverflow =
-          w.getComputedStyle(el, null).overflow === 'visible';
-      } while (!isBody && !(hasScrollableSpace && !hasVisibleOverflow));
+        style =  w.getComputedStyle(el, null);
+        hasVisibleOverflow = style.overflow === 'visible';
+        isFixed = style.position === 'fixed';
+        
+      } while (!isFixed && !isBody && !(hasScrollableSpace && !hasVisibleOverflow));
 
-      isBody = hasScrollableSpace = hasVisibleOverflow = null;
+      isFixed = style = isBody = hasScrollableSpace = hasVisibleOverflow = null;
 
       return el;
     }


### PR DESCRIPTION
I have a fixed sidebar in my project. When i call `element.scrollIntoView()` for an element inside that sidebar and there is no scroll in it, the body gets scrolled with the same amount which is definitely unintended behavior. 
This fix has worked for me, though I'm not 100% it will not break something else. Hope you guys can help me with this.