### PR TITLE
Feat(#32): add Element.scroll/To/By methods

### DIFF
--- a/dist/smoothscroll.js
+++ b/dist/smoothscroll.js
@@ -243,6 +243,23 @@
       );
     };
 
+    // Element.prototype.scrollBy
+    Element.prototype.scrollBy = function() {
+      // avoid smooth behavior if not required
+      if (shouldBailOut(arguments[0])) {
+        original.scrollIntoView.call(this, arguments[0] || true);
+        return;
+      }
+
+      // LET THE SMOOTHNESS BEGIN!
+      smoothScroll.call(
+        this,
+        this,
+        this.scrollLeft + arguments[0].left,
+        this.scrollTop + arguments[0].top
+      );
+    };
+
     // Element.prototype.scrollIntoView
     Element.prototype.scrollIntoView = function() {
       // avoid smooth behavior if not required

--- a/dist/smoothscroll.js
+++ b/dist/smoothscroll.js
@@ -270,9 +270,11 @@
       var arg0 = arguments[0];
 
       if (typeof arg0 === 'object') {
-        arg0.left += this.scrollLeft;
-        arg0.top += this.scrollTop;
-        this.scroll(arg0);
+        this.scroll({
+          left: arg0.left + this.scrollLeft,
+          top: arg0.top + this.scrollTop,
+          behavior: arg0.behavior
+        });
       } else {
         this.scroll(
           this.scrollLeft + arg0,

--- a/dist/smoothscroll.js
+++ b/dist/smoothscroll.js
@@ -33,6 +33,7 @@
     var original = {
       scroll: w.scroll || w.scrollTo,
       scrollBy: w.scrollBy,
+      elScroll: Element.prototype.scroll || scrollElement,
       scrollIntoView: Element.prototype.scrollIntoView
     };
 
@@ -243,21 +244,41 @@
       );
     };
 
-    // Element.prototype.scrollBy
-    Element.prototype.scrollBy = function() {
+    // Element.prototype.scroll and Element.prototype.scrollTo
+    Element.prototype.scroll = Element.prototype.scrollTo = function() {
       // avoid smooth behavior if not required
       if (shouldBailOut(arguments[0])) {
-        original.scrollIntoView.call(this, arguments[0] || true);
+        original.elScroll.call(
+            this,
+            arguments[0].left || arguments[0],
+            arguments[0].top || arguments[1]
+        );
         return;
       }
 
       // LET THE SMOOTHNESS BEGIN!
       smoothScroll.call(
-        this,
-        this,
-        this.scrollLeft + arguments[0].left,
-        this.scrollTop + arguments[0].top
+          this,
+          this,
+          arguments[0].left,
+          arguments[0].top
       );
+    };
+
+    // Element.prototype.scrollBy
+    Element.prototype.scrollBy = function() {
+      var arg0 = arguments[0];
+
+      if (typeof arg0 === 'object') {
+        arg0.left += this.scrollLeft;
+        arg0.top += this.scrollTop;
+        this.scroll(arg0);
+      } else {
+        this.scroll(
+          this.scrollLeft + arg0,
+          this.scrollTop + arguments[1]
+        );
+      }
     };
 
     // Element.prototype.scrollIntoView

--- a/index.html
+++ b/index.html
@@ -235,12 +235,22 @@
     </div>
   </section>
 
+  <section class="sample sample-elementScrollToTop">
+    <div class="container">
+      <h2>element.scroll <small>or</small> element.scrollTo</h2>
+      <pre><code>element.scrollTo({ top: 0, left: 0, behavior: 'smooth' });</code></pre>
+      <div class="actions">
+        <button class="btn js-elementScrollToTop">scroll element to top</button>
+      </div>
+    </div>
+  </section>
+
   <section class="sample sample-scrollBy2">
     <div class="container">
       <h2>element.scrollBy</h2>
       <pre><code>element.scrollBy({ top: 100, left: 0, behavior: 'smooth' });</code></pre>
       <div class="actions">
-        <button class="btn js-scroll-by2">scroll by 100 pixels</button>
+        <button class="btn js-scroll-by2">scroll element by 100 pixels</button>
       </div>
     </div>
   </section>
@@ -309,6 +319,12 @@
       document.querySelector('.js-scroll-into-hello').addEventListener('click', function(e) {
         e.preventDefault();
         document.querySelector('.hello').scrollIntoView({ behavior: 'smooth' });
+      });
+
+      // element scroll to
+      document.querySelector('.js-elementScrollToTop').addEventListener('click', function(e) {
+        e.preventDefault();
+        document.querySelector('.scrollable-parent').scroll({ top: 0, left: 0, behavior: 'smooth' });
       });
 
       // element scroll by

--- a/index.html
+++ b/index.html
@@ -235,6 +235,16 @@
     </div>
   </section>
 
+  <section class="sample sample-scrollBy2">
+    <div class="container">
+      <h2>element.scrollBy</h2>
+      <pre><code>element.scrollBy({ top: 100, left: 0, behavior: 'smooth' });</code></pre>
+      <div class="actions">
+        <button class="btn js-scroll-by2">scroll by 100 pixels</button>
+      </div>
+    </div>
+  </section>
+
   <section class="sample sample-scrollToTop">
     <div class="container">
       <h2>Scroll to top</h2>
@@ -299,6 +309,12 @@
       document.querySelector('.js-scroll-into-hello').addEventListener('click', function(e) {
         e.preventDefault();
         document.querySelector('.hello').scrollIntoView({ behavior: 'smooth' });
+      });
+
+      // element scroll by
+      document.querySelector('.js-scroll-by2').addEventListener('click', function(e) {
+        e.preventDefault();
+        document.querySelector('.scrollable-parent').scrollBy({ top: 100, left: 0, behavior: 'smooth' });
       });
     });
   </script>

--- a/src/smoothscroll.js
+++ b/src/smoothscroll.js
@@ -237,6 +237,23 @@
       );
     };
 
+    // Element.prototype.scrollBy
+    Element.prototype.scrollBy = function() {
+      // avoid smooth behavior if not required
+      if (shouldBailOut(arguments[0])) {
+        original.scrollIntoView.call(this, arguments[0] || true);
+        return;
+      }
+
+      // LET THE SMOOTHNESS BEGIN!
+      smoothScroll.call(
+        this,
+        this,
+        this.scrollLeft + arguments[0].left,
+        this.scrollTop + arguments[0].top
+      );
+    };
+
     // Element.prototype.scrollIntoView
     Element.prototype.scrollIntoView = function() {
       // avoid smooth behavior if not required

--- a/src/smoothscroll.js
+++ b/src/smoothscroll.js
@@ -261,19 +261,18 @@
 
     // Element.prototype.scrollBy
     Element.prototype.scrollBy = function() {
-      // avoid smooth behavior if not required
-      if (shouldBailOut(arguments[0])) {
-        original.scrollIntoView.call(this, arguments[0] || true);
-        return;
-      }
+      var arg0 = arguments[0];
 
-      // LET THE SMOOTHNESS BEGIN!
-      smoothScroll.call(
-        this,
-        this,
-        this.scrollLeft + arguments[0].left,
-        this.scrollTop + arguments[0].top
-      );
+      if (typeof arg0 === 'object') {
+        arg0.left += this.scrollLeft;
+        arg0.top += this.scrollTop;
+        this.scroll(arg0);
+      } else {
+        this.scroll(
+          this.scrollLeft + arg0,
+          this.scrollTop + arguments[1]
+        );
+      }
     };
 
     // Element.prototype.scrollIntoView

--- a/src/smoothscroll.js
+++ b/src/smoothscroll.js
@@ -27,6 +27,7 @@
     var original = {
       scroll: w.scroll || w.scrollTo,
       scrollBy: w.scrollBy,
+      elScroll: Element.prototype.scroll || scrollElement,
       scrollIntoView: Element.prototype.scrollIntoView
     };
 
@@ -234,6 +235,27 @@
         d.body,
         ~~arguments[0].left + (w.scrollX || w.pageXOffset),
         ~~arguments[0].top + (w.scrollY || w.pageYOffset)
+      );
+    };
+
+    // Element.prototype.scroll and Element.prototype.scrollTo
+    Element.prototype.scroll = Element.prototype.scrollTo = function() {
+      // avoid smooth behavior if not required
+      if (shouldBailOut(arguments[0])) {
+        original.elScroll.call(
+            this,
+            arguments[0].left || arguments[0],
+            arguments[0].top || arguments[1]
+        );
+        return;
+      }
+
+      // LET THE SMOOTHNESS BEGIN!
+      smoothScroll.call(
+          this,
+          this,
+          arguments[0].left,
+          arguments[0].top
       );
     };
 

--- a/src/smoothscroll.js
+++ b/src/smoothscroll.js
@@ -264,9 +264,11 @@
       var arg0 = arguments[0];
 
       if (typeof arg0 === 'object') {
-        arg0.left += this.scrollLeft;
-        arg0.top += this.scrollTop;
-        this.scroll(arg0);
+        this.scroll({
+          left: arg0.left + this.scrollLeft,
+          top: arg0.top + this.scrollTop,
+          behavior: arg0.behavior
+        });
       } else {
         this.scroll(
           this.scrollLeft + arg0,


### PR DESCRIPTION
as per new draft spec version, as mentioned in issue https://github.com/iamdustan/smoothscroll/issues/32
https://drafts.csswg.org/cssom-view/#extension-to-the-element-interface

~This PR only adds `Element.prototype.scrollBy`, it does not address `scrollTo` nor anything else yet.~

Also added a dedicated section on the `index.html` demo page for immediate test:
https://ghybs.github.io/smoothscroll/

Tested on Firefox 51, Chromium 53, Opera 43.

NOTE: it might be interesting to refactor `Element.prototype.scrollIntoView` call to `smoothScroll` using `scrollableParent.scrollBy`?