### PR TITLE
changed scrollIntoView to target all scrollable parents

### DIFF
--- a/dist/smoothscroll.js
+++ b/dist/smoothscroll.js
@@ -252,14 +252,15 @@
       }
 
       // LET THE SMOOTHNESS BEGIN!
-      var scrollableParent = findScrollableParent(this);
+      var el = this;
+      var scrollableParent = findScrollableParent(el);
       var parentRects = scrollableParent.getBoundingClientRect();
-      var clientRects = this.getBoundingClientRect();
+      var clientRects = el.getBoundingClientRect();
 
-      if (scrollableParent !== d.body) {
+      while (scrollableParent !== d.body) {
         // reveal element inside parent
         smoothScroll.call(
-          this,
+          el,
           scrollableParent,
           scrollableParent.scrollLeft + clientRects.left - parentRects.left,
           scrollableParent.scrollTop + clientRects.top - parentRects.top
@@ -270,13 +271,21 @@
           top: parentRects.top,
           behavior: 'smooth'
         });
-      } else {
-        // reveal element in viewport
-        w.scrollBy({
-          left: clientRects.left,
-          top: clientRects.top,
-          behavior: 'smooth'
-        });
+
+        el = scrollableParent;
+        scrollableParent = findScrollableParent(el);
+        parentRects = scrollableParent.getBoundingClientRect();
+        clientRects = el.getBoundingClientRect();
+
+      }
+      // reveal element in viewport
+      w.scrollBy({
+        left: clientRects.left,
+        top: clientRects.top,
+        behavior: 'smooth'
+      });
+    };
+  }
       }
     };
   }

--- a/index.html
+++ b/index.html
@@ -224,7 +224,35 @@
         adipisci consequuntur maiores, quo in nulla ratione facere distinctio beatae, quae consequatur ab labore dolorum.</p>
         <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Qui iure obcaecati, repudiandae aspernatur cumque recusandae
         adipisci consequuntur maiores, quo in nulla ratione facere distinctio beatae, quae consequatur ab labore dolorum.</p>
-        <h3 class="hello"><em>hello!</em></h3>
+        <article class="scrollable-parent">
+          <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Qui iure obcaecati, repudiandae aspernatur cumque recusandae
+          adipisci consequuntur maiores, quo in nulla ratione facere distinctio beatae, quae consequatur ab labore dolorum.</p>
+          <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Qui iure obcaecati, repudiandae aspernatur cumque recusandae
+          adipisci consequuntur maiores, quo in nulla ratione facere distinctio beatae, quae consequatur ab labore dolorum.</p>
+          <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Qui iure obcaecati, repudiandae aspernatur cumque recusandae
+          adipisci consequuntur maiores, quo in nulla ratione facere distinctio beatae, quae consequatur ab labore dolorum.</p>
+          <article class="scrollable-parent">
+            <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Qui iure obcaecati, repudiandae aspernatur cumque recusandae
+            adipisci consequuntur maiores, quo in nulla ratione facere distinctio beatae, quae consequatur ab labore dolorum.</p>
+            <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Qui iure obcaecati, repudiandae aspernatur cumque recusandae
+            adipisci consequuntur maiores, quo in nulla ratione facere distinctio beatae, quae consequatur ab labore dolorum.</p>
+            <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Qui iure obcaecati, repudiandae aspernatur cumque recusandae
+            adipisci consequuntur maiores, quo in nulla ratione facere distinctio beatae, quae consequatur ab labore dolorum.</p>
+            <h3 class="hello"><em>hello!</em></h3>
+            <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Qui iure obcaecati, repudiandae aspernatur cumque recusandae
+            adipisci consequuntur maiores, quo in nulla ratione facere distinctio beatae, quae consequatur ab labore dolorum.</p>
+            <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Qui iure obcaecati, repudiandae aspernatur cumque recusandae
+            adipisci consequuntur maiores, quo in nulla ratione facere distinctio beatae, quae consequatur ab labore dolorum.</p>
+            <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Qui iure obcaecati, repudiandae aspernatur cumque recusandae
+            adipisci consequuntur maiores, quo in nulla ratione facere distinctio beatae, quae consequatur ab labore dolorum.</p>
+          </article>
+          <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Qui iure obcaecati, repudiandae aspernatur cumque recusandae
+          adipisci consequuntur maiores, quo in nulla ratione facere distinctio beatae, quae consequatur ab labore dolorum.</p>
+          <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Qui iure obcaecati, repudiandae aspernatur cumque recusandae
+          adipisci consequuntur maiores, quo in nulla ratione facere distinctio beatae, quae consequatur ab labore dolorum.</p>
+          <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Qui iure obcaecati, repudiandae aspernatur cumque recusandae
+          adipisci consequuntur maiores, quo in nulla ratione facere distinctio beatae, quae consequatur ab labore dolorum.</p>
+        </article>
         <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Qui iure obcaecati, repudiandae aspernatur cumque recusandae
         adipisci consequuntur maiores, quo in nulla ratione facere distinctio beatae, quae consequatur ab labore dolorum.</p>
         <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Qui iure obcaecati, repudiandae aspernatur cumque recusandae

--- a/src/smoothscroll.js
+++ b/src/smoothscroll.js
@@ -246,14 +246,15 @@
       }
 
       // LET THE SMOOTHNESS BEGIN!
-      var scrollableParent = findScrollableParent(this);
+      var el = this;
+      var scrollableParent = findScrollableParent(el);
       var parentRects = scrollableParent.getBoundingClientRect();
-      var clientRects = this.getBoundingClientRect();
+      var clientRects = el.getBoundingClientRect();
 
-      if (scrollableParent !== d.body) {
+      while (scrollableParent !== d.body) {
         // reveal element inside parent
         smoothScroll.call(
-          this,
+          el,
           scrollableParent,
           scrollableParent.scrollLeft + clientRects.left - parentRects.left,
           scrollableParent.scrollTop + clientRects.top - parentRects.top
@@ -264,14 +265,19 @@
           top: parentRects.top,
           behavior: 'smooth'
         });
-      } else {
-        // reveal element in viewport
-        w.scrollBy({
-          left: clientRects.left,
-          top: clientRects.top,
-          behavior: 'smooth'
-        });
+
+        el = scrollableParent;
+        scrollableParent = findScrollableParent(el);
+        parentRects = scrollableParent.getBoundingClientRect();
+        clientRects = el.getBoundingClientRect();
+
       }
+      // reveal element in viewport
+      w.scrollBy({
+        left: clientRects.left,
+        top: clientRects.top,
+        behavior: 'smooth'
+      });
     };
   }
 


### PR DESCRIPTION
I ran into an issue working with this polyfill's scrollIntoView on a site ([this one](https://github.com/dawaltconley/onyx)) that has a body set to `height: 100%` with all of the page's content existing in a scrollable child div. Any direct children of that div would scroll as expected, but if the target of the scroll was nested within another scrollable div (think the 'hello!' section of your example) the main-page div wouldn't scroll down to it. This was different behavior from the default scrollIntoView method, which *would* scroll to the element in Firefox.

Changing the if statement in the polyfill to a while loop fixed this for me, and improves how it works in other cases of nested scrollable divs.

For what it's worth, this doesn't seem to to be *quite* how the default method works. On the modified home page, Firefox will 1) scroll each div until the target element is at the top of its parent---unless the target element is *already* at the top of it's parent, in which case do the same to the next scrollable parent, etc.---and 2) also scroll the body down so the top of the viewport is aligned with the element. This is *almost* what the polyfill does, but not quite, as multiple clicks in Firefox will eventually bring the element to where it wants to be, whereas multiple clicks with the polyfill will not.

I feel like the while loop method is the most flexible option, as it works no matter which element is functioning as the page body, and brings the element into view with one click no matter what. But I don't know what the word is on having polyfills deviate from the default behavior, even if they end up performing slightly better. It's also is a pretty unlikely scenario where it makes a real difference (who nests multiple scrollable divs?) but thought I'd share this sorta-solution rather than opening an issue. :)