### PR TITLE
Fix npm link on website

### DIFF
--- a/index.html
+++ b/index.html
@@ -254,7 +254,7 @@
   <section class="featured">
     <div class="container">
       <a class="featured__link" href="https://github.com/iamdustan/smoothscroll">Polyfill on <strong>GitHub</strong></a>
-      <a class="featured__link" href="https://github.com/iamdustan/smoothscroll-polyfill">Polyfill on <strong>npm</strong></a>
+      <a class="featured__link" href="https://www.npmjs.com/package/smoothscroll-polyfill">Polyfill on <strong>npm</strong></a>
       <a class="featured__link" href="https://drafts.csswg.org/cssom-view/#extensions-to-the-window-interface">Draft on <strong>W3C</strong></a>
       <a class="featured__link" href="https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-behavior">Documentation on <strong>MDN</strong></a>
     </div>


### PR DESCRIPTION
The "Polyfill on npm" link points to `https://github.com/iamdustan/smoothscroll-polyfill` (which does not exist). It should probably be `https://www.npmjs.com/package/smoothscroll-polyfill`.