### PR TITLE
Only attempt to do work in animation frame if there is still scrolling to do

### DIFF
--- a/src/smoothscroll.js
+++ b/src/smoothscroll.js
@@ -119,9 +119,6 @@
      * @param {Object} context
      */
     function step(context) {
-      // call method again on next available frame
-      context.frame = w.requestAnimationFrame(step.bind(w, context));
-
       var time = now();
       var value;
       var currentX;
@@ -139,10 +136,9 @@
 
       context.method.call(context.scrollable, currentX, currentY);
 
-      // return when end points have been reached
-      if (currentX === context.x && currentY === context.y) {
-        w.cancelAnimationFrame(context.frame);
-        return;
+      // scroll more if we have not reached our destination
+      if (currentX !== context.x || currentY !== context.y) {
+        w.requestAnimationFrame(step.bind(w, context));
       }
     }
 
@@ -159,7 +155,6 @@
       var startY;
       var method;
       var startTime = now();
-      var frame;
 
       // define scroll context
       if (el === d.body) {
@@ -174,11 +169,6 @@
         method = scrollElement;
       }
 
-      // cancel frame when a scroll event's happening
-      if (frame) {
-        w.cancelAnimationFrame(frame);
-      }
-
       // scroll looping over a frame
       step({
         scrollable: scrollable,
@@ -187,8 +177,7 @@
         startX: startX,
         startY: startY,
         x: x,
-        y: y,
-        frame: frame
+        y: y
       });
     }
 


### PR DESCRIPTION
Rather than registering more scroll stepping only to cancel later, delay
registering a new animation frame call until we know if we need it.

This fixes a bug in our application [where some other library replaced the
requestAnimationFrame function](https://github.com/mozilla/pdf.js/pull/8222) to not return a frameId and thus made the
request un-cancelable.  It also however is a simpler way to accomplish the same
behavior.