### PR TITLE
Fix for issue #45-- don't try and scroll a position:fixed element into view

### DIFF
--- a/src/smoothscroll.js
+++ b/src/smoothscroll.js
@@ -287,12 +287,14 @@
           scrollableParent.scrollLeft + clientRects.left - parentRects.left,
           scrollableParent.scrollTop + clientRects.top - parentRects.top
         );
-        // reveal parent in viewport
-        w.scrollBy({
-          left: parentRects.left,
-          top: parentRects.top,
-          behavior: 'smooth'
-        });
+        if (w.getComputedStyle(scrollableParent).position != 'fixed') {
+          // reveal parent in viewport
+          w.scrollBy({
+            left: parentRects.left,
+            top: parentRects.top,
+            behavior: 'smooth'
+          });
+        }
       } else {
         // reveal element in viewport
         w.scrollBy({


### PR DESCRIPTION
Issue https://github.com/iamdustan/smoothscroll/issues/45 shows an issue where if the parent element is position:fixed, smoothscroll tries to scroll the body to scroll it to the top of the viewport.  position:fixed elements never move of course, so in this case, it shouldn't do anything to the scrollpos of the body.