### PR TITLE
Add override() to override native implementation

### DIFF
--- a/dist/smoothscroll.js
+++ b/dist/smoothscroll.js
@@ -21,6 +21,11 @@
       return;
     }
 
+    override();
+  }
+
+  // override
+  function override() {
     /*
      * globals
      */
@@ -312,7 +317,10 @@
 
   if (typeof exports === 'object') {
     // commonjs
-    module.exports = { polyfill: polyfill };
+    module.exports = {
+      polyfill: polyfill,
+      override: override
+    };
   } else {
     // global
     polyfill();

--- a/src/smoothscroll.js
+++ b/src/smoothscroll.js
@@ -15,6 +15,11 @@
       return;
     }
 
+    override();
+  }
+
+  // override
+  function override() {
     /*
      * globals
      */
@@ -306,7 +311,10 @@
 
   if (typeof exports === 'object') {
     // commonjs
-    module.exports = { polyfill: polyfill };
+    module.exports = {
+      polyfill: polyfill,
+      override: override
+    };
   } else {
     // global
     polyfill();


### PR DESCRIPTION
Unfortunately, current browser implementations are unstable. Current Chrome's implementation does not work well but we cannot apply smoothscroll polyfill because [containing `scrollBehavior` property](https://github.com/iamdustan/smoothscroll/blob/master/src/smoothscroll.js#L14). (We cannot delete that property with `delete document.documentElement.style.scrollBehavior;`!)

`override()` allows you to override native functions with this polyfill that works well.

Will resolve #52, #49.