### PR TITLE
fixes #66

### DIFF
--- a/dist/smoothscroll.js
+++ b/dist/smoothscroll.js
@@ -245,12 +245,15 @@
         return;
       }
 
+      var left = arguments[0].left;
+      var top = arguments[0].top;
+
       // LET THE SMOOTHNESS BEGIN!
       smoothScroll.call(
           this,
           this,
-          arguments[0].left,
-          arguments[0].top
+          typeof left === 'number' ? left : this.scrollLeft,
+          typeof top === 'number' ? top : this.scrollTop
       );
     };
 

--- a/src/smoothscroll.js
+++ b/src/smoothscroll.js
@@ -239,12 +239,15 @@
         return;
       }
 
+      var left = arguments[0].left;
+      var top = arguments[0].top;
+
       // LET THE SMOOTHNESS BEGIN!
       smoothScroll.call(
           this,
           this,
-          arguments[0].left,
-          arguments[0].top
+          typeof left === 'number' ? left : this.scrollLeft,
+          typeof top === 'number' ? top : this.scrollTop
       );
     };
 


### PR DESCRIPTION
If either `left` or `top` is omitted (`undefined`) `step` continues to make rAF calls as `NaN !== undefined`.
Thats the reason for the bug in #66 :)