### PR TITLE
Fix for Issue #73: findScrollableParent false positives in IE

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ bower_components
 
 // npm
 npm_debug.log
+npm-debug.log
 
 // OS X
 .DS_Store

--- a/src/smoothscroll.js
+++ b/src/smoothscroll.js
@@ -289,7 +289,10 @@
     Element.prototype.scrollIntoView = function() {
       // avoid smooth behavior if not required
       if (shouldBailOut(arguments[0])) {
-        original.scrollIntoView.call(this, arguments[0] === undefined ? true : arguments[0]);
+        original.scrollIntoView.call(
+          this,
+          arguments[0] === undefined ? true : arguments[0]
+        );
         return;
       }
 

--- a/src/smoothscroll.js
+++ b/src/smoothscroll.js
@@ -86,12 +86,28 @@
     }
 
     /**
+     * indicates if a the current browser is made by Microsoft
+     * @method isMicrosoftBrowser
+     * @param {string} userAgent
+     * @returns {Boolean}
+     */
+    function isMicrosoftBrowser(userAgent) {
+      var userAgentPatterns = ['MSIE ', 'Trident/', 'Edge/'];
+      return new RegExp(userAgentPatterns.join('|')).test(userAgent);
+    }
+
+    /**
      * finds scrollable parent of an element
      * @method findScrollableParent
      * @param {Node} el
      * @returns {Node} el
      */
     function findScrollableParent(el) {
+      /*
+        Microsoft browsers can round a computed height that contains a
+        fraction of a pixel up for clientHeight, and down for scrollHeight.
+      */
+      var roundingTolerance = isMicrosoftBrowser(w.navigator.userAgent) ? 1 : 0;
       var isBody;
       var hasScrollableSpace;
       var hasVisibleOverflow;
@@ -102,8 +118,8 @@
         // set condition variables
         isBody = el === d.body;
         hasScrollableSpace =
-          el.clientHeight < el.scrollHeight ||
-          el.clientWidth < el.scrollWidth;
+          el.clientHeight + roundingTolerance < el.scrollHeight ||
+          el.clientWidth + roundingTolerance < el.scrollWidth;
         hasVisibleOverflow =
           w.getComputedStyle(el, null).overflow === 'visible';
       } while (!isBody && !(hasScrollableSpace && !hasVisibleOverflow));

--- a/src/smoothscroll.js
+++ b/src/smoothscroll.js
@@ -15,11 +15,23 @@
       return;
     }
 
+    /**
+     * indicates if a the current browser is made by Microsoft
+     * @method isMicrosoftBrowser
+     * @param {string} userAgent
+     * @returns {Boolean}
+     */
+    function isMicrosoftBrowser(userAgent) {
+      var userAgentPatterns = ['MSIE ', 'Trident/', 'Edge/'];
+      return new RegExp(userAgentPatterns.join('|')).test(userAgent);
+    }
+
     /*
      * globals
      */
     var Element = w.HTMLElement || w.Element;
     var SCROLL_TIME = 468;
+    var ROUNDING_TOLERANCE = isMicrosoftBrowser(w.navigator.userAgent) ? 1 : 0;
 
     /*
      * object gathering original scroll methods
@@ -86,28 +98,12 @@
     }
 
     /**
-     * indicates if a the current browser is made by Microsoft
-     * @method isMicrosoftBrowser
-     * @param {string} userAgent
-     * @returns {Boolean}
-     */
-    function isMicrosoftBrowser(userAgent) {
-      var userAgentPatterns = ['MSIE ', 'Trident/', 'Edge/'];
-      return new RegExp(userAgentPatterns.join('|')).test(userAgent);
-    }
-
-    /**
      * finds scrollable parent of an element
      * @method findScrollableParent
      * @param {Node} el
      * @returns {Node} el
      */
     function findScrollableParent(el) {
-      /*
-        Microsoft browsers can round a computed height that contains a
-        fraction of a pixel up for clientHeight, and down for scrollHeight.
-      */
-      var roundingTolerance = isMicrosoftBrowser(w.navigator.userAgent) ? 1 : 0;
       var isBody;
       var hasScrollableSpace;
       var hasVisibleOverflow;
@@ -118,8 +114,8 @@
         // set condition variables
         isBody = el === d.body;
         hasScrollableSpace =
-          el.clientHeight + roundingTolerance < el.scrollHeight ||
-          el.clientWidth + roundingTolerance < el.scrollWidth;
+          el.clientHeight + ROUNDING_TOLERANCE < el.scrollHeight ||
+          el.clientWidth + ROUNDING_TOLERANCE < el.scrollWidth;
         hasVisibleOverflow =
           w.getComputedStyle(el, null).overflow === 'visible';
       } while (!isBody && !(hasScrollableSpace && !hasVisibleOverflow));


### PR DESCRIPTION
### About
IE has rounding bug, where a calculated height can be rounded down to the nearest whole pixel `clientHeight` and is rounded up for `scrollHeight`. This causes  the`hasScrollableSpace` check within `findScrollableParent`, which compares these two values for a given element, to sometimes return a false positive.

### Changes
- Proposed fix for #73 by detecting the current user agent and applying a tolerance where appropriate.
- Fixes pre-existing linting error for line length in master.
- Add the [default `npm-debug.log` filename](https://docs.npmjs.com/misc/config#loglevel) to `.gitignore`