### PR TITLE
Improve reliability of findScrollableParent

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,6 +2,7 @@
   "name": "smoothscroll",
   "description": "Polyfill for smooth scroll behavior",
   "main": "dist/smoothscroll.js",
+  "version": "0.3.6",
   "authors": [
     "Dustan Kasten",
     "Jeremias Menichelli"

--- a/dist/smoothscroll.js
+++ b/dist/smoothscroll.js
@@ -1,5 +1,5 @@
 /*
- * smoothscroll polyfill - v0.3.5
+ * smoothscroll polyfill - v0.3.6
  * https://iamdustan.github.io/smoothscroll
  * 2016 (c) Dustan Kasten, Jeremias Menichelli - MIT License
  */
@@ -99,22 +99,33 @@
      */
     function findScrollableParent(el) {
       var isBody;
-      var hasScrollableSpace;
-      var hasVisibleOverflow;
+      var hasVerticalScrollableSpace;
+      var hasHorizontalScrollableSpace;
+      var hasVerticalVisibleOverflow;
+      var hasHorizontalVisibleOverflow;
+      var isVerticallyScrollable;
+      var isHorizontallyScrollable;
 
       do {
         el = el.parentNode;
-
         // set condition variables
         isBody = el === d.body;
-        hasScrollableSpace =
-          el.clientHeight < el.scrollHeight ||
-          el.clientWidth < el.scrollWidth;
-        hasVisibleOverflow =
-          w.getComputedStyle(el, null).overflow === 'visible';
-      } while (!isBody && !(hasScrollableSpace && !hasVisibleOverflow));
+        hasVerticalScrollableSpace = el.clientHeight < el.scrollHeight;
+        hasHorizontalScrollableSpace = el.clientWidth < el.scrollWidth;
+        hasVerticalVisibleOverflow =
+          w.getComputedStyle(el, null).overflowY === 'visible';
+        hasHorizontalVisibleOverflow =
+          w.getComputedStyle(el, null).overflowX === 'visible';
+        isVerticallyScrollable =
+          hasVerticalScrollableSpace && !hasVerticalVisibleOverflow;
+        isHorizontallyScrollable =
+          hasHorizontalScrollableSpace && !hasHorizontalVisibleOverflow;
+      } while (!isBody &&
+        !(isVerticallyScrollable || isHorizontallyScrollable));
 
-      isBody = hasScrollableSpace = hasVisibleOverflow = null;
+      isBody = hasVerticalScrollableSpace = hasHorizontalScrollableSpace =
+        hasVerticalVisibleOverflow = hasHorizontalVisibleOverflow =
+        isVerticallyScrollable = isHorizontallyScrollable = null;
 
       return el;
     }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "title": "smoothscroll",
   "name": "smoothscroll-polyfill",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "author": {
     "name": "Dustan Kasten",
     "email": "dustan.kasten@gmail.com",

--- a/src/smoothscroll.js
+++ b/src/smoothscroll.js
@@ -93,22 +93,35 @@
      */
     function findScrollableParent(el) {
       var isBody;
-      var hasScrollableSpace;
-      var hasVisibleOverflow;
+      var hasVerticalScrollableSpace;
+      var hasHorizontalScrollableSpace;
+      var hasVerticalVisibleOverflow;
+      var hasHorizontalVisibleOverflow;
+      var isVerticallyScrollable;
+      var isHorizontallyScrollable;
 
       do {
         el = el.parentNode;
 
         // set condition variables
         isBody = el === d.body;
-        hasScrollableSpace =
-          el.clientHeight < el.scrollHeight ||
-          el.clientWidth < el.scrollWidth;
-        hasVisibleOverflow =
-          w.getComputedStyle(el, null).overflow === 'visible';
-      } while (!isBody && !(hasScrollableSpace && !hasVisibleOverflow));
 
-      isBody = hasScrollableSpace = hasVisibleOverflow = null;
+        hasVerticalScrollableSpace = el.clientHeight < el.scrollHeight;
+        hasHorizontalScrollableSpace = el.clientWidth < el.scrollWidth;
+        hasVerticalVisibleOverflow =
+          w.getComputedStyle(el, null).overflowY === 'visible';
+        hasHorizontalVisibleOverflow =
+          w.getComputedStyle(el, null).overflowX === 'visible';
+        isVerticallyScrollable =
+          hasVerticalScrollableSpace && !hasVerticalVisibleOverflow;
+        isHorizontallyScrollable =
+          hasHorizontalScrollableSpace && !hasHorizontalVisibleOverflow;
+      } while (!isBody &&
+        !(isVerticallyScrollable || isHorizontallyScrollable));
+
+      isBody = hasVerticalScrollableSpace = hasHorizontalScrollableSpace =
+        hasVerticalVisibleOverflow = hasHorizontalVisibleOverflow =
+        isVerticallyScrollable = isHorizontallyScrollable = null;
 
       return el;
     }
@@ -273,7 +286,7 @@
     Element.prototype.scrollIntoView = function() {
       // avoid smooth behavior if not required
       if (shouldBailOut(arguments[0])) {
-        original.scrollIntoView.call(this, arguments[0] === undefined ? true : arguments[0]);
+        original.scrollIntoView.call(this, arguments[0] || true);
         return;
       }
 


### PR DESCRIPTION
Improves reliability of `findScrollableParent` by accounting differently for horizontal and vertical overflows. This fixes a bug I encountered where a div was overflowing horizontally causing the whole window to be horizontally scrolled, even though `overflow-x: visible;` was applied. The commit adds separate checks for `overflow-x` and `overlfow-y`. The cases included in index.html seem to be working just fine.