### PR TITLE
Placed a check for `undefined` for arguments in `scrollTo`.

### DIFF
--- a/src/smoothscroll.js
+++ b/src/smoothscroll.js
@@ -228,27 +228,29 @@
     };
 
     // Element.prototype.scroll and Element.prototype.scrollTo
-    Element.prototype.scroll = Element.prototype.scrollTo = function() {
-      // avoid smooth behavior if not required
-      if (shouldBailOut(arguments[0])) {
-        original.elScroll.call(
+    Element.prototype.scroll = Element.prototype.scrollTo = function() {    
+      if (arguments[0]) {
+        // avoid smooth behavior if not required
+        if (shouldBailOut(arguments[0])) {
+          original.elScroll.call(
+              this,
+              arguments[0].left || arguments[0],
+              arguments[0].top || arguments[1]
+          );
+          return;
+        }
+
+        var left = arguments[0].left;
+        var top = arguments[0].top;
+
+        // LET THE SMOOTHNESS BEGIN!
+        smoothScroll.call(
             this,
-            arguments[0].left || arguments[0],
-            arguments[0].top || arguments[1]
+            this,
+            typeof left === 'number' ? left : this.scrollLeft,
+            typeof top === 'number' ? top : this.scrollTop
         );
-        return;
       }
-
-      var left = arguments[0].left;
-      var top = arguments[0].top;
-
-      // LET THE SMOOTHNESS BEGIN!
-      smoothScroll.call(
-          this,
-          this,
-          typeof left === 'number' ? left : this.scrollLeft,
-          typeof top === 'number' ? top : this.scrollTop
-      );
     };
 
     // Element.prototype.scrollBy


### PR DESCRIPTION
On using this script on my page along with jQuery and flickity.js, I was getting the following error

`Uncaught TypeError: Cannot read property 'left' of undefined
    at HTMLDivElement.Element.scroll.Element.scrollTo `

Full error stacktrace:

smoothscroll.js?v=38.5:244 Uncaught TypeError: Cannot read property 'left' of undefined
    at HTMLDivElement.Element.scroll.Element.scrollTo (smoothscroll.js?v=38.5:244)
    at Object.trigger (jquery-2.1.1.min.js?v=38.5:3)
    at HTMLDivElement.<anonymous> (jquery-2.1.1.min.js?v=38.5:3)
    at Function.each (jquery-2.1.1.min.js?v=38.5:2)
    at n.fn.init.each (jquery-2.1.1.min.js?v=38.5:2)
    at n.fn.init.trigger (jquery-2.1.1.min.js?v=38.5:3)
    at h.p.dispatchEvent (flickity.pkgd.min.js?v=38.5:12)
    at h.s.positionSlider (flickity.pkgd.min.js?v=38.5:12)
    at h.s.positionSliderAtSelected (flickity.pkgd.min.js?v=38.5:12)
    at h.p.select (flickity.pkgd.min.js?v=38.5:12)