### PR TITLE
Server-Side Rendering (SSR) - avoids "ReferenceError: window is not defined" 

### DIFF
--- a/src/smoothscroll.js
+++ b/src/smoothscroll.js
@@ -5,8 +5,14 @@
  * w: window global object
  * d: document
  */
-var w = window;
-var d = document;
+var w;
+var d;
+
+// avoids "ReferenceError: window is not defined" when running in node
+if (typeof window !== 'undefined') {
+  w = window;
+  d = document;
+}
 
 /**
  * indicates if a the current browser is made by Microsoft
@@ -438,6 +444,15 @@ function polyfill() {
 if (typeof exports === 'object') {
   // commonjs
   module.exports = { polyfill: polyfill };
+
+  // avoids "ReferenceError: window is not defined" when running in node
+  if (typeof window === 'undefined') {
+    module.exports = {
+      polyfill: function() {
+        // do nothing.
+      }
+    };
+  }
 } else {
   // global
   polyfill();


### PR DESCRIPTION
When running in node the code is breaking with the following exception:
> "ReferenceError: window is not defined"

... and stops exactly [here](https://github.com/iamdustan/smoothscroll/blob/6f3ffac080c6b8080ebddebcb342c20a32541c34/dist/smoothscroll.js#L10).

**Expected behavior:**
the polyfill can be included, not matter if its executed in the client or on the server. I'm fine when the code is doing nothing on the server - but it should not yield to an exception.

As far as I can see, the functionality was working in the past (I was on 0.3.5 previously), but it stopped working after the rollup-rewrite, because of [this](https://github.com/iamdustan/smoothscroll/blob/9da17b4b73808ac0c0b8f512a5ec157bbeb0c541/src/smoothscroll.js#L314) to [this](}()) and several other changes.

**About the PR**
This PR works around the issue by checking `typeof window` first and by replacing the main `polyfill()` with an empty-function (commonjs only, as it makes no sense to fix global code).

Cheers!