### PR TITLE
Move browser globals for SSR. Safer CJS check.

### DIFF
--- a/src/smoothscroll.js
+++ b/src/smoothscroll.js
@@ -1,31 +1,31 @@
 'use strict';
 
-/*
- * aliases
- * w: window global object
- * d: document
- */
-var w = window;
-var d = document;
-
-/**
- * indicates if a the current browser is made by Microsoft
- * @method isMicrosoftBrowser
- * @param {String} userAgent
- * @returns {Boolean}
- */
-function isMicrosoftBrowser(userAgent) {
-  var userAgentPatterns = ['MSIE ', 'Trident/', 'Edge/'];
-
-  return new RegExp(userAgentPatterns.join('|')).test(userAgent);
-}
-
- // polyfill
 function polyfill() {
+
+  /*
+   * aliases
+   * w: window global object
+   * d: document
+   */
+  var w = window;
+  var d = document;
+
   // return if scroll behavior is supported and polyfill is not forced
   if ('scrollBehavior' in d.documentElement.style
-    && w.__forceSmoothScrollPolyfill__ !== true) {
+      && w.__forceSmoothScrollPolyfill__ !== true) {
     return;
+  }
+
+  /**
+   * indicates if a the current browser is made by Microsoft
+   * @method isMicrosoftBrowser
+   * @param {String} userAgent
+   * @returns {Boolean}
+   */
+  function isMicrosoftBrowser(userAgent) {
+    var userAgentPatterns = ['MSIE ', 'Trident/', 'Edge/'];
+
+    return new RegExp(userAgentPatterns.join('|')).test(userAgent);
   }
 
   // globals
@@ -435,7 +435,8 @@ function polyfill() {
   };
 }
 
-if (typeof exports === 'object') {
+if (typeof exports === 'object'
+    && typeof module !== 'undefined') {
   // commonjs
   module.exports = { polyfill: polyfill };
 } else {


### PR DESCRIPTION
This pull request fixes two things:
 - It first provides a safer check for CJS imports, something that was reported in the past so I'm following the same pattern as Rollup and checking both `exports` and `module`
 - I'm moving all the code inside the polyfill function to avoid errors in server side rendering situations. We've just got reported a PR for that, but I don't think the polyfill should care indeed about SSR, but before there was NO way people could get a escape hatch on the server side. With this change the could just do this:

```js
import smoothscroll from 'smoothscroll-polyfill'

if (typeof window !== 'undefined') {
  smoothscorll.polyfill();
}
```
