### PR TITLE
Make it possible to scrollIntoView() to document.body

### DIFF
--- a/src/smoothscroll.js
+++ b/src/smoothscroll.js
@@ -158,6 +158,10 @@ function polyfill() {
   function findScrollableParent(el) {
     var isBody;
 
+    if (el === d.body) {
+      return el;
+    }
+
     do {
       el = el.parentNode;
 


### PR DESCRIPTION
This PR enables the following scroll.

```js
document.body.scrollIntoView({
  behavior: 'smooth'
})
```
