### PR TITLE
fix smoothscroll not working with shadow DOM

### DIFF
--- a/src/smoothscroll.js
+++ b/src/smoothscroll.js
@@ -159,6 +159,7 @@ function polyfill() {
     while (el !== d.body && isScrollable(el) === false) {
       el = el.parentNode || el.host;
     }
+    
     return el;
   }
 

--- a/src/smoothscroll.js
+++ b/src/smoothscroll.js
@@ -159,7 +159,7 @@ function polyfill() {
     while (el !== d.body && isScrollable(el) === false) {
       el = el.parentNode || el.host;
     }
-    
+
     return el;
   }
 

--- a/src/smoothscroll.js
+++ b/src/smoothscroll.js
@@ -157,9 +157,8 @@ function polyfill() {
    */
   function findScrollableParent(el) {
     while (el !== d.body && isScrollable(el) === false) {
-      el = el.parentNode;
+      el = el.parentNode || el.host;
     }
-
     return el;
   }
 


### PR DESCRIPTION
Adding the el.host will allow this plugin to work with shadow DOM. Before that, el.parentNode on a shadow-root returned null and failed.