### PR TITLE
Allow to configure scroll time

### DIFF
--- a/src/smoothscroll.js
+++ b/src/smoothscroll.js
@@ -1,7 +1,14 @@
 'use strict';
 
+var DEFAULT_OPTS = {
+  scrollTime: 468
+};
+
 // polyfill
-function polyfill() {
+function polyfill(opts) {
+  // setting up default options
+  opts = opts || DEFAULT_OPTS;
+
   // aliases
   var w = window;
   var d = document;
@@ -16,7 +23,7 @@ function polyfill() {
 
   // globals
   var Element = w.HTMLElement || w.Element;
-  var SCROLL_TIME = 468;
+  var SCROLL_TIME = opts.scrollTime || DEFAULT_OPTS.scrollTime;
 
   // object gathering original scroll methods
   var original = {


### PR DESCRIPTION
Be able to optionally parameterise scroll speed when polyfilled:
- This allows to more appropriately match Safari to e.g. Chrome or Firefox browsers
- Non-breaking/backwards compatible change

Alternatively, something like `var SCROLL_TIME = 250;` is a more closer approximation to common scrolling time in Chrome or FF.