### PR TITLE
Accept window and document arguments in polyfill method

### DIFF
--- a/src/smoothscroll.js
+++ b/src/smoothscroll.js
@@ -1,11 +1,7 @@
 'use strict';
 
 // polyfill
-function polyfill() {
-  // aliases
-  var w = window;
-  var d = document;
-
+function polyfill(w = window, d = document) {
   // return if scroll behavior is supported and polyfill is not forced
   if (
     'scrollBehavior' in d.documentElement.style &&


### PR DESCRIPTION
This will allow the window and document context to be overridden, useful when targeting another document on the page (e.g. an iframe)