### PR TITLE
handle detached elements

### DIFF
--- a/src/smoothscroll.js
+++ b/src/smoothscroll.js
@@ -156,7 +156,7 @@ function polyfill() {
    * @returns {Node} el
    */
   function findScrollableParent(el) {
-    while (el !== d.body && isScrollable(el) === false) {
+    while (el != null && el !== d.body && isScrollable(el) === false) {
       el = el.parentNode || el.host;
     }
 

--- a/src/smoothscroll.js
+++ b/src/smoothscroll.js
@@ -389,6 +389,7 @@ function polyfill() {
 
     // LET THE SMOOTHNESS BEGIN!
     var scrollableParent = findScrollableParent(this);
+    if (scrollableParent == null) return;
     var parentRects = scrollableParent.getBoundingClientRect();
     var clientRects = this.getBoundingClientRect();
 


### PR DESCRIPTION
Scenario: I have a call to smoothscroll in a callback. So if I nav away from the page prior to the callback running, the element is no longer attached to the DOM.