### PR TITLE
Implement relative scroll time from distance

### DIFF
--- a/src/smoothscroll.js
+++ b/src/smoothscroll.js
@@ -18,6 +18,8 @@ function polyfill() {
   var Element = w.HTMLElement || w.Element;
   var MIN_SCROLL_TIME = 200;
   var MAX_SCROLL_TIME = 468;
+  // Scroll animation speed in pixels / ms
+  var SCROLL_SPEED = 1;
 
   // object gathering original scroll methods
   var original = {
@@ -226,13 +228,11 @@ function polyfill() {
     const distanceToScrollX = Math.abs(x - startX);
     const distanceToScrollY = Math.abs(y - startY);
     const maxDistanceToScroll = Math.max(distanceToScrollX, distanceToScrollY);
-    // Configure the speed animation in pixels/ms
-    const animationSpeed = 1;
     // Calculate the time needed for the scroll animation
     const scrollTime =
     Math.max(
       MIN_SCROLL_TIME,
-      Math.min(MAX_SCROLL_TIME, maxDistanceToScroll * animationSpeed)
+      Math.min(MAX_SCROLL_TIME, maxDistanceToScroll * SCROLL_SPEED)
     );
 
     // scroll looping over a frame

--- a/src/smoothscroll.js
+++ b/src/smoothscroll.js
@@ -222,10 +222,17 @@ function polyfill() {
       method = scrollElement;
     }
 
-    const maxDistance = Math.max(Math.abs(x - startX), Math.abs(y - startY));
-    const scrollTime = Math.max(
+    // Calculate the maximum distance to scroll in pixels
+    const distanceToScrollX = Math.abs(x - startX);
+    const distanceToScrollY = Math.abs(y - startY);
+    const maxDistanceToScroll = Math.max(distanceToScrollX, distanceToScrollY);
+    // Configure the speed animation in pixels/ms
+    const animationSpeed = 1;
+    // Calculate the time needed for the scroll animation
+    const scrollTime =
+    Math.max(
       MIN_SCROLL_TIME,
-      Math.min(MAX_SCROLL_TIME, maxDistance)
+      Math.min(MAX_SCROLL_TIME, maxDistanceToScroll * animationSpeed)
     );
 
     // scroll looping over a frame
@@ -256,14 +263,14 @@ function polyfill() {
         arguments[0].left !== undefined
           ? arguments[0].left
           : typeof arguments[0] !== 'object'
-          ? arguments[0]
-          : w.scrollX || w.pageXOffset,
+            ? arguments[0]
+            : w.scrollX || w.pageXOffset,
         // use top prop, second argument if present or fallback to scrollY
         arguments[0].top !== undefined
           ? arguments[0].top
           : arguments[1] !== undefined
-          ? arguments[1]
-          : w.scrollY || w.pageYOffset
+            ? arguments[1]
+            : w.scrollY || w.pageYOffset
       );
 
       return;

--- a/src/smoothscroll.js
+++ b/src/smoothscroll.js
@@ -16,7 +16,8 @@ function polyfill() {
 
   // globals
   var Element = w.HTMLElement || w.Element;
-  var SCROLL_TIME = 468;
+  var MIN_SCROLL_TIME = 200;
+  var MAX_SCROLL_TIME = 468;
 
   // object gathering original scroll methods
   var original = {
@@ -174,7 +175,7 @@ function polyfill() {
     var value;
     var currentX;
     var currentY;
-    var elapsed = (time - context.startTime) / SCROLL_TIME;
+    var elapsed = (time - context.startTime) / context.scrollTime;
 
     // avoid elapsed times higher than one
     elapsed = elapsed > 1 ? 1 : elapsed;
@@ -221,6 +222,12 @@ function polyfill() {
       method = scrollElement;
     }
 
+    const maxDistance = Math.max(Math.abs(x - startX), Math.abs(y - startY));
+    const scrollTime = Math.max(
+      MIN_SCROLL_TIME,
+      Math.min(MAX_SCROLL_TIME, maxDistance)
+    );
+
     // scroll looping over a frame
     step({
       scrollable: scrollable,
@@ -229,7 +236,8 @@ function polyfill() {
       startX: startX,
       startY: startY,
       x: x,
-      y: y
+      y: y,
+      scrollTime
     });
   }
 
@@ -248,14 +256,14 @@ function polyfill() {
         arguments[0].left !== undefined
           ? arguments[0].left
           : typeof arguments[0] !== 'object'
-            ? arguments[0]
-            : w.scrollX || w.pageXOffset,
+          ? arguments[0]
+          : w.scrollX || w.pageXOffset,
         // use top prop, second argument if present or fallback to scrollY
         arguments[0].top !== undefined
           ? arguments[0].top
           : arguments[1] !== undefined
-            ? arguments[1]
-            : w.scrollY || w.pageYOffset
+          ? arguments[1]
+          : w.scrollY || w.pageYOffset
       );
 
       return;


### PR DESCRIPTION
The SCROLL_TIME is a magic number of 468ms.
I would like to use this great polyfill in https://github.com/luispuig/react-snaplist-carousel but this time is too long.

My first thought was making it configurable but then I read https://github.com/iamdustan/smoothscroll/pull/140 and https://github.com/iamdustan/smoothscroll/issues/65

> Hey @vkatushenok! Just got back from holiday. @jeremenichelli and I have spoken about something like this before and I’m generally against making it customizable. If you could find constants that different UAs and OSes use for this I’d be happy to see an approach pursued that tries to more accurately emulate the differences.

I agree

> tbh it's pretty arbitrary. Ideally, we would calculate the total scroll diff to make ahead of time and have the SCROLL_TIME be dynamic based upon that.

Here I got the idea of using the scroll distance to calculate the scroll time.

I set up some min and max scroll times.

Left: Firefox, Center: Chrome, Right: Safari using the polyfill

![speed](https://user-images.githubusercontent.com/24297787/100383409-d4f5de80-301d-11eb-9491-b1c951832d3f.gif)

Chrome makes the animation much faster than Firefox and different ease. So, I tried to adjust something in the middle.

P.D: Great work with this polyfill :D