### PR TITLE
Extend shouldBailOut to check for existence of attached DOM element

### DIFF
--- a/src/smoothscroll.js
+++ b/src/smoothscroll.js
@@ -92,6 +92,11 @@ function polyfill() {
       return true;
     }
 
+    if (firstArg.parentNode !== 'object' && !firstArg.host) {
+      // first argument is not attached to any DOM element
+      return true;
+    }
+
     if (typeof firstArg === 'object' && firstArg.behavior === 'smooth') {
       // first argument is an object and behavior is smooth
       return false;


### PR DESCRIPTION
This extends `shouldBailOut` to ensure that the provided DOM element reference is still attached to the DOM, we had a situation where we called `scrollIntoView` on an element that had since been removed which would throw `TypeError: undefined is not an object (evaluating 'el.clientHeight')
(anonymous function) — smoothscroll.js:117` and cause scrolling to break.

I believe this should fix #138 and may also resolve #161.